### PR TITLE
[PKG-5755] sacrebleu 2.4.3 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e734b1e0baeaea6ade0fefc9d23bac3df50bf15775d8b78edc108db63654192a
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - sacrebleu = sacrebleu.sacrebleu:main
@@ -22,6 +22,7 @@ requirements:
     - python
     - pip
     - setuptools
+    - setuptools_scm
     - wheel
   run:
     - python


### PR DESCRIPTION
sacrebleu 2.4.3

**Destination channel:** defaults

### Links

- [PKG-5755](https://anaconda.atlassian.net/browse/PKG-5755) 
- [Upstream repository](https://github.com/mjpost/sacrebleu/tree/v2.4.3)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/fairseq-feedstock/pull/1

### Explanation of changes:

- Pip check fails with version 0.0.0 in `fairseq 0.12.2`. Need to rebuild and add `setuptools_scm`.


[PKG-5755]: https://anaconda.atlassian.net/browse/PKG-5755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ